### PR TITLE
firepad-tabs-fix

### DIFF
--- a/browser/Components/FirepadTabs.js
+++ b/browser/Components/FirepadTabs.js
@@ -5,6 +5,8 @@ import Editors from './Editors';
 
 export const FirepadTabs = () => {
 
+    const handleClick = (event) => {}
+
     let HTMLEditor = Editors[0];
     let CSSEditor = Editors[1];
     let JSEditor = Editors[2];


### PR DESCRIPTION
handleclick was no longer defined, and that was throwing an error that prevented entire webpage from rendering